### PR TITLE
Fix #6 Add gson adapter for HttpCookie for java 16+

### DIFF
--- a/src/main/java/com/faforever/client/preferences/PreferencesService.java
+++ b/src/main/java/com/faforever/client/preferences/PreferencesService.java
@@ -10,6 +10,7 @@ import com.faforever.client.preferences.gson.ExcludeFieldsWithExcludeAnnotationS
 import com.faforever.client.preferences.gson.PathTypeAdapter;
 import com.faforever.client.preferences.gson.PropertyTypeAdapter;
 import com.faforever.client.remote.gson.FactionTypeAdapter;
+import com.faforever.client.remote.gson.HttpCookieTypeAdapter;
 import com.faforever.client.update.ClientConfiguration;
 import com.faforever.client.util.Assert;
 import com.github.nocatch.NoCatch.NoCatchRunnable;
@@ -149,6 +150,7 @@ public class PreferencesService implements InitializingBean {
         .registerTypeAdapter(Color.class, new ColorTypeAdapter())
         .registerTypeAdapter(Faction.class, FactionTypeAdapter.INSTANCE)
         .registerTypeAdapter(ObservableMap.class, FactionTypeAdapter.INSTANCE)
+        .registerTypeAdapter(java.net.HttpCookie.class, HttpCookieTypeAdapter.INSTANCE)
         .create();
   }
 

--- a/src/main/java/com/faforever/client/remote/gson/HttpCookieTypeAdapter.java
+++ b/src/main/java/com/faforever/client/remote/gson/HttpCookieTypeAdapter.java
@@ -1,0 +1,35 @@
+package com.faforever.client.remote.gson;
+
+import com.faforever.client.game.Faction;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.net.HttpCookie;
+
+public class HttpCookieTypeAdapter extends TypeAdapter<HttpCookie> {
+
+  public static final HttpCookieTypeAdapter INSTANCE = new HttpCookieTypeAdapter();
+
+  private HttpCookieTypeAdapter() {
+    // private
+  }
+
+  @Override
+  public void write(JsonWriter out, HttpCookie value) throws IOException {
+    out.value(value.getName());
+    out.value(value.getValue());
+  }
+
+  @Override
+  public HttpCookie read(JsonReader in) throws IOException {
+    if (in.peek() == JsonToken.NULL) {
+      in.nextNull();
+      return null;
+    }
+
+    return new HttpCookie(in.nextString(), in.nextString());
+   }
+}


### PR DESCRIPTION
Allows client to run on java 16 and probably higher.

Fixes #6 