### PR TITLE
Fix scrollbar showing at bottom of chat box when using long messages.

### DIFF
--- a/src/main/resources/theme/style-webview.css
+++ b/src/main/resources/theme/style-webview.css
@@ -5,6 +5,7 @@ All the following applies to the content of a WebViews (chat, news), therefore i
 *****************/
 
 html, body {
+  /*background: #212121;*/
   background-color: transparent;
   margin: 0;
   padding: 0;
@@ -31,10 +32,11 @@ a {
 
 .chat-section {
   overflow: hidden;
+  width: 100%;
 }
 
-.chat-section * {
-  word-wrap: break-word;
+.text {
+  word-break: break-word;
 }
 
 .chat-section.extended {
@@ -58,6 +60,7 @@ img.country-flag {
 
 .chat-section-head {
   margin-bottom: 0.2em;
+  width: 100%;
 }
 
 .chat-section .clan-tag:empty {


### PR DESCRIPTION
old behaviour:
![image](https://github.com/ta-forever/downlords-taf-client/assets/29734170/e4b3f70c-6cea-4995-9f11-b9fab69429bd)

new behaviour:
![image](https://github.com/ta-forever/downlords-taf-client/assets/29734170/46fc11c2-0527-46fc-8e2d-904a62a4224e)

note that even if a word is really long it will get wrapped correctly, including URLs.