### PR TITLE
Better username autocompletion in chats

### DIFF
--- a/src/main/java/com/faforever/client/chat/ChannelTabController.java
+++ b/src/main/java/com/faforever/client/chat/ChannelTabController.java
@@ -160,7 +160,25 @@ public class ChannelTabController extends AbstractChatTabController {
 
     autoCompletionHelper = new AutoCompletionHelper(
         currentWord -> userNamesToListItems.keySet().stream()
-            .filter(playerName -> playerName.toLowerCase(US).startsWith(currentWord.toLowerCase()))
+            .filter(playerName -> {
+              // Case-insensitive matching: lowercase both name and search word
+              String lowerName = playerName.toLowerCase(US);
+              String lowerCurrent = currentWord.toLowerCase(US);
+
+              if (lowerCurrent.contains("_")) {
+                // If the user types an underscore, match the entire username directly
+                return lowerName.startsWith(lowerCurrent);
+              } else {
+                // Split the username into parts at all underscores and match any part
+                for (String part : lowerName.split("_")) {
+                  if (part.startsWith(lowerCurrent)) {
+                    return true;
+                  }
+                }
+                // No part matched
+                return false;
+              }
+            })
             .sorted()
             .collect(Collectors.toList())
     );

--- a/src/main/java/com/faforever/client/chat/MatchmakingChatController.java
+++ b/src/main/java/com/faforever/client/chat/MatchmakingChatController.java
@@ -72,7 +72,25 @@ public class MatchmakingChatController extends AbstractChatTabController {
     autoCompletionHelper = new AutoCompletionHelper(
         currentWord -> chatChannelUsers.stream()
             .map(ChatChannelUser::getUsername)
-            .filter(playerName -> playerName.toLowerCase(US).startsWith(currentWord.toLowerCase()))
+            .filter(playerName -> {
+                // Case-insensitive matching: lowercase both name and search word
+                String lowerName = playerName.toLowerCase(US);
+                String lowerCurrent = currentWord.toLowerCase(US);
+
+                if (lowerCurrent.contains("_")) {
+                    // If the user types an underscore, match the entire username directly
+                    return lowerName.startsWith(lowerCurrent);
+                } else {
+                    // Split the username into parts at all underscores and match any part
+                    for (String part : lowerName.split("_")) {
+                        if (part.startsWith(lowerCurrent)) {
+                            return true;
+                        }
+                    }
+                    // No part matched
+                    return false;
+                }
+            })
             .sorted()
             .collect(Collectors.toList())
     );


### PR DESCRIPTION
Autocompletion works on any part of username split at underscores. So there is no need to type the player clan, just the player name.

Before: the user must type the first part of the addressed username including the clan prefix.
After: no need to type the clan, just the username is sufficient.

Details:
Both Channel chat and Matchmaking chat controller classes are modified to improve username autocompletion with the Tab key.
Matching is done by splitting usernames at underscores and checking if the beginning of any part matches the input.  Example: "TRP_Last_Bully" is matched by "tr", "las", or "bull".
If user input itself contains an underscore, the matching is done simply by the full username.