### PR TITLE
Move parenthesis in ErrorLog filename to show the correct file extension.

### DIFF
--- a/src/main/java/com/faforever/client/remote/FafService.java
+++ b/src/main/java/com/faforever/client/remote/FafService.java
@@ -421,7 +421,7 @@ public class FafService {
       int i=1;
       Path backupPath;
       do {
-        backupPath = taPath.resolve(String.format("ErrorLog.txt(%d)", i++));
+        backupPath = taPath.resolve(String.format("ErrorLog(%d).txt", i++));
       }
       while (Files.exists(backupPath));
       try {


### PR DESCRIPTION
Was `ErrorLog.txt(1)`, now `ErrorLog(1).txt`