### PR TITLE
Display winning teams on replay cards with persistent checkbox toggle

### DIFF
--- a/src/main/java/com/faforever/client/preferences/VaultPrefs.java
+++ b/src/main/java/com/faforever/client/preferences/VaultPrefs.java
@@ -6,6 +6,8 @@ import javafx.beans.property.MapProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleMapProperty;
 import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableMap;
 import org.jetbrains.annotations.Nullable;
@@ -17,6 +19,7 @@ public class VaultPrefs {
   private final MapProperty<String, String> savedReplayQueries;
   private final MapProperty<String, String> savedMapQueries;
   private final MapProperty<String, String> savedModQueries;
+  private final BooleanProperty showWinnersInReplays;
 
 
   public VaultPrefs() {
@@ -26,6 +29,7 @@ public class VaultPrefs {
     savedReplayQueries = new SimpleMapProperty<>(FXCollections.observableHashMap());
     savedMapQueries = new SimpleMapProperty<>(FXCollections.observableHashMap());
     savedModQueries = new SimpleMapProperty<>(FXCollections.observableHashMap());
+    showWinnersInReplays = new SimpleBooleanProperty(true);
   }
 
   public SortConfig getOnlineReplaySortConfig() {
@@ -46,6 +50,18 @@ public class VaultPrefs {
 
   public void setMapSortConfig(SortConfig mapSortConfig) {
     this.mapSortConfig.set(mapSortConfig);
+  }
+
+  public boolean isShowWinnersInReplays() {
+    return showWinnersInReplays.get();
+  }
+
+  public void setShowWinnersInReplays(boolean showWinnersInReplays) {
+    this.showWinnersInReplays.set(showWinnersInReplays);
+  }
+
+  public BooleanProperty showWinnersInReplaysProperty() {
+    return showWinnersInReplays;
   }
 
   public ObjectProperty<SortConfig> mapSortConfigProperty() {

--- a/src/main/java/com/faforever/client/replay/OnlineReplayVaultController.java
+++ b/src/main/java/com/faforever/client/replay/OnlineReplayVaultController.java
@@ -88,6 +88,7 @@ public class OnlineReplayVaultController extends VaultEntityController<Replay> {
 
   protected Node getEntityCard(Replay replay) {
     ReplayCardController controller = uiService.loadFxml("theme/vault/replay/replay_card.fxml");
+    controller.setShowWinners(preferencesService.getPreferences().getVault().isShowWinnersInReplays());
     controller.setReplay(replay);
     controller.setOnOpenDetailListener(this::onDisplayDetails);
     return controller.getRoot();
@@ -122,6 +123,14 @@ public class OnlineReplayVaultController extends VaultEntityController<Replay> {
     searchController.setSearchableProperties(SearchablePropertyMappings.GAME_PROPERTY_MAPPING);
     searchController.setSortConfig(preferencesService.getPreferences().getVault().onlineReplaySortConfigProperty());
     searchController.setOnlyShowLastYearCheckBoxVisible(true);
+    searchController.setShowWinnersCheckBoxVisible(true);
+    searchController.showWinnersSelectedProperty().bindBidirectional(
+        preferencesService.getPreferences().getVault().showWinnersInReplaysProperty()
+    );
+    searchController.showWinnersSelectedProperty().addListener((observable, oldValue, newValue) -> {
+      preferencesService.storeInBackground();
+      onRefreshButtonClicked();
+    });
     searchController.setVaultRoot(vaultRoot);
     searchController.setSavedQueries(preferencesService.getPreferences().getVault().getSavedReplayQueries());
 

--- a/src/main/java/com/faforever/client/replay/Replay.java
+++ b/src/main/java/com/faforever/client/replay/Replay.java
@@ -41,6 +41,7 @@ import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -384,10 +385,30 @@ public class Replay {
     if (getTeams().size() <= 1) {
       return Optional.empty();
     }
-    return getTeamPlayerStats().entrySet().stream()
-        .max(java.util.Comparator.comparingInt(entry ->
-            entry.getValue().stream().mapToInt(PlayerStats::getScore).sum()))
-        .map(java.util.Map.Entry::getKey);
+
+    // 1. Try to determine winner by Score
+    Map<String, Integer> scoreTotals = getTeamPlayerStats().entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().stream().mapToInt(PlayerStats::getScore).sum()));
+
+    Integer maxScore = scoreTotals.values().stream().max(Integer::compareTo).orElse(0);
+    List<String> scoreWinners = scoreTotals.entrySet().stream()
+        .filter(e -> e.getValue().equals(maxScore)).map(Map.Entry::getKey).toList();
+
+    if (scoreWinners.size() == 1) {
+      return Optional.of(scoreWinners.get(0));
+    }
+
+    // 2. Fallback: Determine winner by MeanDelta
+    Map<String, Double> deltaTotals = getTeamPlayerStats().entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().stream()
+            .mapToDouble(s -> (s.getBeforeMean() == null || s.getAfterMean() == null) ? 0d : s.getAfterMean() - s.getBeforeMean())
+            .sum()));
+
+    double maxDelta = deltaTotals.values().stream().mapToDouble(Double::doubleValue).max().orElse(0.0);
+    List<String> deltaWinners = deltaTotals.entrySet().stream()
+        .filter(e -> Double.compare(e.getValue(), maxDelta) == 0).map(Map.Entry::getKey).toList();
+
+    return (deltaWinners.size() == 1) ? Optional.of(deltaWinners.get(0)) : Optional.empty();
   }
 
   public MapProperty<String, List<PlayerStats>> teamPlayerStatsProperty() {

--- a/src/main/java/com/faforever/client/replay/Replay.java
+++ b/src/main/java/com/faforever/client/replay/Replay.java
@@ -380,6 +380,16 @@ public class Replay {
     this.teamPlayerStats.set(teamPlayerStats);
   }
 
+  public Optional<String> getWinningTeamId() {
+    if (getTeams().size() <= 1) {
+      return Optional.empty();
+    }
+    return getTeamPlayerStats().entrySet().stream()
+        .max(java.util.Comparator.comparingInt(entry ->
+            entry.getValue().stream().mapToInt(PlayerStats::getScore).sum()))
+        .map(java.util.Map.Entry::getKey);
+  }
+
   public MapProperty<String, List<PlayerStats>> teamPlayerStatsProperty() {
     return teamPlayerStats;
   }

--- a/src/main/java/com/faforever/client/replay/ReplayCardController.java
+++ b/src/main/java/com/faforever/client/replay/ReplayCardController.java
@@ -74,6 +74,7 @@ public class ReplayCardController implements Controller<Node> {
   public Button unhideButton;
   public Label visibilityLabel;
   private Replay replay;
+  private boolean showWinners;
   private final InvalidationListener reviewsChangedListener = observable -> populateReviews();
   private Consumer<Replay> onOpenDetailListener;
 
@@ -169,11 +170,17 @@ public class ReplayCardController implements Controller<Node> {
           .orElse(i18n.get("notAvailable")));
     }
 
+    Optional<String> winningTeamId = showWinners ? replay.getWinningTeamId() : Optional.empty();
+
     replay.getTeams()
         .forEach((id, team) -> {
           VBox teamBox = new VBox();
 
           String teamLabelText = id.equals("1") ? i18n.get("replay.noTeam") : i18n.get("replay.team", Integer.parseInt(id) - 1);
+          if (winningTeamId.map(id::equals).orElse(false)) {
+            teamLabelText += " 👑";
+          }
+
           Label teamLabel = new Label(teamLabelText);
           teamLabel.getStyleClass().add("replay-card-team-label");
           teamLabel.setPadding(new Insets(0, 0, 5, 0));
@@ -186,6 +193,10 @@ public class ReplayCardController implements Controller<Node> {
     ObservableList<Review> reviews = replay.getReviews();
     JavaFxUtil.addListener(reviews, new WeakInvalidationListener(reviewsChangedListener));
     reviewsChangedListener.invalidated(reviews);
+  }
+
+  public void setShowWinners(boolean showWinners) {
+    this.showWinners = showWinners;
   }
 
   private void populateReviews() {

--- a/src/main/java/com/faforever/client/vault/search/SearchController.java
+++ b/src/main/java/com/faforever/client/vault/search/SearchController.java
@@ -21,6 +21,7 @@ import com.github.rutledgepaulv.qbuilders.conditions.Condition;
 import com.github.rutledgepaulv.qbuilders.visitors.RSQLVisitor;
 import javafx.beans.InvalidationListener;
 import javafx.beans.binding.BooleanBinding;
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.ObservableMap;
 import javafx.scene.control.Button;
@@ -64,6 +65,7 @@ public class SearchController implements Controller<Pane> {
   public Pane criteriaPane;
   public TextField queryTextField;
   public CheckBox displayQueryCheckBox;
+  public CheckBox showWinnersCheckBox;
   public Button searchButton;
   public Button saveQueryButton;
   public Button savedQueriesButton;
@@ -100,12 +102,13 @@ public class SearchController implements Controller<Pane> {
 
   @Override
   public void initialize() {
-    JavaFxUtil.bindManagedToVisible(queryTextField, criteriaPane, filterPane, onlyShowLastYearCheckBox,
+    JavaFxUtil.bindManagedToVisible(queryTextField, criteriaPane, filterPane, onlyShowLastYearCheckBox, showWinnersCheckBox,
         initialLogicalNodeController.logicalOperatorField, initialLogicalNodeController.removeCriteriaButton,
         addCriteriaButton);
 
     saveQueryButton.disableProperty().bind(queryTextField.textProperty().isEmpty());
     queryTextField.visibleProperty().bind(displayQueryCheckBox.selectedProperty());
+    showWinnersCheckBox.setVisible(false);
 
     initialLogicalNodeController.logicalOperatorField.setValue(null);
     initialLogicalNodeController.logicalOperatorField.setDisable(true);
@@ -418,6 +421,14 @@ public class SearchController implements Controller<Pane> {
   public void setOnlyShowLastYearCheckBoxVisible(boolean visible) {
     showLastYearCheckBox = visible;
     onlyShowLastYearCheckBox.setSelected(visible);
+  }
+
+  public void setShowWinnersCheckBoxVisible(boolean visible) {
+    showWinnersCheckBox.setVisible(visible);
+  }
+
+  public BooleanProperty showWinnersSelectedProperty() {
+    return showWinnersCheckBox.selectedProperty();
   }
 
   public void setVaultRoot(StackPane root) {

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -1885,6 +1885,8 @@ vault.onlineReplays = TAF Replays
 
 # Checkbox: display search query
 vault.replays.displayQuery = Display search query
+# Checkbox: show winners on replay cards
+vault.replays.showWinners = Show winners
 # Section heading: most highly rated replays
 vault.replays.highestRated = Highest Rated
 # Section heading: most recent replays

--- a/src/main/resources/theme/vault/search/search.fxml
+++ b/src/main/resources/theme/vault/search/search.fxml
@@ -45,6 +45,7 @@
                 mnemonicParsing="false"
                 onAction="#onSavedQueriesButtonClicked" text="%vault.savedQueries"/>
         <CheckBox fx:id="displayQueryCheckBox" mnemonicParsing="false" text="%vault.replays.displayQuery"/>
+        <CheckBox fx:id="showWinnersCheckBox" mnemonicParsing="false" text="%vault.replays.showWinners" visible="false"/>
     </HBox>
     <TextField fx:id="queryTextField" onAction="#onSearchButtonClicked" maxWidth="1.7976931348623157E308"
                promptText="%vault.replays.queryPrompt"/>


### PR DESCRIPTION
Adds winner team marking to replay cards in the Replays tab and introduces a **Show winners** checkbox in the search panel next to **Display search query**. The checkbox state is persisted in user settings, defaults to enabled for new users, and toggling it refreshes the visible replay list so cards update immediately.

Implementation:
Winner detection is derived in `Replay.java` via `getWinningTeamId()`, which returns the ID of the team with the highest aggregate `PlayerStats.score` or highest aggregate PlayerStats.beforeMean/afterMean delta as a fallback, skips single-team and inconclusive cases. 
The shared vault search UI is extended in `SearchController.java` and `search.fxml`, but the new checkbox is only enabled in `OnlineReplayVaultController.java`.
Persistence is handled through `VaultPrefs.java`, and replay cards consume the setting in `ReplayCardController.java` to conditionally render the winner marker.