### PR TITLE
Show map environment stats and extra preview modes

### DIFF
--- a/src/main/java/com/faforever/client/fa/MapTool.java
+++ b/src/main/java/com/faforever/client/fa/MapTool.java
@@ -1,6 +1,7 @@
 package com.faforever.client.fa;
 
 import com.faforever.client.map.MapService.PreviewType;
+import com.faforever.client.map.MapService.PreviewOverlayType;
 
 import com.google.gson.Gson;
 import org.slf4j.Logger;
@@ -28,6 +29,7 @@ public class MapTool {
   public static final Integer MAP_DETAIL_COLUMN_WIND = 6;
   public static final Integer MAP_DETAIL_COLUMN_TIDAL = 7;
   public static final Integer MAP_DETAIL_COLUMN_GRAVITY = 8;
+  public static final Integer MAP_DETAIL_COLUMN_WATER_PERCENT = 9;
 
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -35,18 +37,23 @@ public class MapTool {
     List<Map<String, String>> mapDetails = new ArrayList();
     for (String[] values : _mapDetails) {
       Map<String, String> keyvals = new HashMap();
-      keyvals.put("name", values[MAP_DETAIL_COLUMN_NAME]);
-      keyvals.put("archive", values[MAP_DETAIL_COLUMN_ARCHIVE]);
-      keyvals.put("crc", values[MAP_DETAIL_COLUMN_CRC]);
-      keyvals.put("description", values[MAP_DETAIL_COLUMN_DESCRIPTION]);
-      keyvals.put("size", values[MAP_DETAIL_COLUMN_SIZE]);
-      keyvals.put("players", values[MAP_DETAIL_COLUMN_NUM_PLAYERS]);
-      keyvals.put("wind", values[MAP_DETAIL_COLUMN_WIND]);
-      keyvals.put("tidal", values[MAP_DETAIL_COLUMN_TIDAL]);
-      keyvals.put("gravity", values[MAP_DETAIL_COLUMN_GRAVITY]);
+      keyvals.put("name", valueAt(values, MAP_DETAIL_COLUMN_NAME));
+      keyvals.put("archive", valueAt(values, MAP_DETAIL_COLUMN_ARCHIVE));
+      keyvals.put("crc", valueAt(values, MAP_DETAIL_COLUMN_CRC));
+      keyvals.put("description", valueAt(values, MAP_DETAIL_COLUMN_DESCRIPTION));
+      keyvals.put("size", valueAt(values, MAP_DETAIL_COLUMN_SIZE));
+      keyvals.put("players", valueAt(values, MAP_DETAIL_COLUMN_NUM_PLAYERS));
+      keyvals.put("wind", valueAt(values, MAP_DETAIL_COLUMN_WIND));
+      keyvals.put("tidal", valueAt(values, MAP_DETAIL_COLUMN_TIDAL));
+      keyvals.put("gravity", valueAt(values, MAP_DETAIL_COLUMN_GRAVITY));
+      keyvals.put("waterPercent", valueAt(values, MAP_DETAIL_COLUMN_WATER_PERCENT));
       mapDetails.add(keyvals);
     }
     return mapDetails;
+  }
+
+  private static String valueAt(String[] values, int index) {
+    return values.length > index ? values[index] : "";
   }
 
   static public String toJson(List<String[]> mapDetails) {
@@ -64,18 +71,26 @@ public class MapTool {
 
   static public List<String[]> listMapsInArchive(Path hpiFile, Path previewCacheDirectory, boolean doCrc) throws IOException {
     // and generate minimap images in previewCacheDirectory if not null
-    return run(hpiFile.getParent(), hpiFile.getFileName().toString(), null, doCrc, previewCacheDirectory, PreviewType.MINI, 0, null);
+    return run(hpiFile.getParent(), hpiFile.getFileName().toString(), null, doCrc, previewCacheDirectory, PreviewType.MINI.getToolName(), 0, null);
   }
 
   public static void generatePreview(Path gamePath, String modGp3FileName, String mapName, Path previewCacheDirectory, PreviewType previewType, int maxPositions) throws IOException {
+    generatePreview(gamePath, modGp3FileName, mapName, previewCacheDirectory, previewType.getToolName(), maxPositions);
+  }
+
+  public static void generateOverlayPreview(Path gamePath, String modGp3FileName, String mapName, Path previewCacheDirectory, PreviewOverlayType previewOverlayType, int maxPositions) throws IOException {
+    generatePreview(gamePath, modGp3FileName, mapName, previewCacheDirectory, previewOverlayType.getToolName(), maxPositions);
+  }
+
+  private static void generatePreview(Path gamePath, String modGp3FileName, String mapName, Path previewCacheDirectory, String previewToolName, int maxPositions) throws IOException {
     String hpiSpecs = "*.hpi;*.gpf;*.ccx;rev31.gp3;*.ufo";
     if (modGp3FileName != null) {
       hpiSpecs = "*.hpi;*.gpf;*.ccx;" + modGp3FileName + ";*.ufo";
     }
-    run(gamePath, hpiSpecs, mapName + "$", false, previewCacheDirectory, previewType, maxPositions, previewCacheDirectory);
+    run(gamePath, hpiSpecs, mapName + "$", false, previewCacheDirectory, previewToolName, maxPositions, previewCacheDirectory);
   }
 
-  static private List<String[]> run(Path gamePath, String hpiSpecs, String mapName, boolean doCrc, Path previewCacheDirectory, PreviewType previewType, int maxPositions, Path featuresCacheDirectory) throws IOException {
+  static private List<String[]> run(Path gamePath, String hpiSpecs, String mapName, boolean doCrc, Path previewCacheDirectory, String previewToolName, int maxPositions, Path featuresCacheDirectory) throws IOException {
     String nativeDir = System.getProperty("nativeDir", "lib");
     Path exe = Paths.get(nativeDir).resolve("bin").resolve(
         org.bridj.Platform.isLinux() ? "maptool" : "maptool.exe"
@@ -106,9 +121,9 @@ public class MapTool {
       command.add("--thumb");
       command.add(previewCacheDirectory.toString());
     }
-    if (previewType != null) {
+    if (previewToolName != null) {
       command.add("--thumbtypes");
-      command.add(previewType.toString().toLowerCase());
+      command.add(previewToolName);
     }
     if (maxPositions > 0) {
       command.add("--maxpositions");

--- a/src/main/java/com/faforever/client/fa/MapTool.java
+++ b/src/main/java/com/faforever/client/fa/MapTool.java
@@ -29,7 +29,6 @@ public class MapTool {
   public static final Integer MAP_DETAIL_COLUMN_WIND = 6;
   public static final Integer MAP_DETAIL_COLUMN_TIDAL = 7;
   public static final Integer MAP_DETAIL_COLUMN_GRAVITY = 8;
-  public static final Integer MAP_DETAIL_COLUMN_WATER_PERCENT = 9;
 
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -46,7 +45,6 @@ public class MapTool {
       keyvals.put("wind", valueAt(values, MAP_DETAIL_COLUMN_WIND));
       keyvals.put("tidal", valueAt(values, MAP_DETAIL_COLUMN_TIDAL));
       keyvals.put("gravity", valueAt(values, MAP_DETAIL_COLUMN_GRAVITY));
-      keyvals.put("waterPercent", valueAt(values, MAP_DETAIL_COLUMN_WATER_PERCENT));
       mapDetails.add(keyvals);
     }
     return mapDetails;

--- a/src/main/java/com/faforever/client/game/CreateGameController.java
+++ b/src/main/java/com/faforever/client/game/CreateGameController.java
@@ -134,7 +134,6 @@ public class CreateGameController implements Controller<Pane> {
   public Label mapPlayersLabel;
   public Label mapWindLabel;
   public Label mapTidalLabel;
-  public Label mapWaterLabel;
   public Label mapDescriptionLabel;
   public TextField mapSearchTextField;
   public TextField titleTextField;
@@ -341,7 +340,6 @@ public class CreateGameController implements Controller<Pane> {
     hpiArchiveLabel.managedProperty().bind(hpiArchiveLabel.visibleProperty());
     mapWindLabel.managedProperty().bind(mapWindLabel.visibleProperty());
     mapTidalLabel.managedProperty().bind(mapTidalLabel.visibleProperty());
-    mapWaterLabel.managedProperty().bind(mapWaterLabel.visibleProperty());
 
     liveReplayOptionComboBox.getItems().setAll(LiveReplayOption.values());
     LiveReplayOption lastGameLiveReplayOption = preferencesService.getPreferences().getLastGame().getLastGameLiveReplayOption();
@@ -904,7 +902,6 @@ public class CreateGameController implements Controller<Pane> {
     mapSizeLabel.setText(i18n.get("mapPreview.size", mapSize.getWidthInKm(), mapSize.getHeightInKm()));
     setSignedMapStatLabel(mapWindLabel, formatWindSpeedRange(mapDetails.getWind()), "mapPreview.wind");
     setSignedMapStatLabel(mapTidalLabel, mapDetails.getTidal(), "mapPreview.tidal");
-    setWaterPercentLabel(mapDetails);
     mapPlayersLabel.setText(i18n.number(mapDetails.getPlayers()));
     mapDescriptionLabel.setText(formatMapDescription(mapDetails.getDescription()));
 
@@ -952,14 +949,6 @@ public class CreateGameController implements Controller<Pane> {
     mapNameLabel.setVisible(!mapNameLabel.getText().isEmpty());
     hpiArchiveLabel.setText(archiveName);
     hpiArchiveLabel.setVisible(!archiveName.isEmpty() && !mapName.isEmpty());
-  }
-
-  private void setWaterPercentLabel(MapBean map) {
-    int waterPercentage = map.getWaterPercentage();
-    mapWaterLabel.setVisible(waterPercentage >= 0);
-    if (waterPercentage >= 0) {
-      mapWaterLabel.setText(i18n.get("mapPreview.water", waterPercentage));
-    }
   }
 
   private String formatWindSpeedRange(String value) {

--- a/src/main/java/com/faforever/client/game/CreateGameController.java
+++ b/src/main/java/com/faforever/client/game/CreateGameController.java
@@ -12,6 +12,7 @@ import com.faforever.client.main.event.SelectGalacticWarMapEvent;
 import com.faforever.client.map.MapBean;
 import com.faforever.client.map.MapBean.Type;
 import com.faforever.client.map.MapService;
+import com.faforever.client.map.MapService.PreviewOverlayType;
 import com.faforever.client.map.MapService.PreviewType;
 import com.faforever.client.map.MapSize;
 import com.faforever.client.mod.FeaturedMod;
@@ -116,6 +117,7 @@ public class CreateGameController implements Controller<Pane> {
   public static final String STYLE_CLASS_DUAL_LIST_CELL = "create-game-dual-list-cell";
   public static final PseudoClass PSEUDO_CLASS_INVALID = PseudoClass.getPseudoClass("invalid");
   private static final int MAX_RATING_LENGTH = 4;
+  private static final double WIND_SPEED_DISPLAY_SCALE = 166.6;
   private final MapService mapService;
   private final ModService modService;
   private final GameService gameService;
@@ -130,6 +132,9 @@ public class CreateGameController implements Controller<Pane> {
 
   public Label mapSizeLabel;
   public Label mapPlayersLabel;
+  public Label mapWindLabel;
+  public Label mapTidalLabel;
+  public Label mapWaterLabel;
   public Label mapDescriptionLabel;
   public TextField mapSearchTextField;
   public TextField titleTextField;
@@ -145,9 +150,12 @@ public class CreateGameController implements Controller<Pane> {
   public Button installGameButton;
   public VBox mapPreview;
   public Pane mapPreviewPane;
+  public Pane mapPreviewOverlayPane;
   public Label versionLabel;
+  public Label mapNameLabel;
   public Label hpiArchiveLabel;
   public ComboBox<PreviewType> mapPreviewTypeComboBox;
+  public ComboBox<PreviewOverlayType> mapPreviewOverlayComboBox;
   public ComboBox<Integer> maxPlayersComboBox;
   public CheckBox onlyForFriendsCheckBox;
   public CheckBox reservedSlotsCheckBox;
@@ -327,9 +335,13 @@ public class CreateGameController implements Controller<Pane> {
     rankedMapPoolsAvailableProperty = new SimpleBooleanProperty();
     selectGalacticWarMapEvent = new SimpleObjectProperty<>();
 
-    JavaFxUtil.addLabelContextMenus(uiService, hpiArchiveLabel, mapDescriptionLabel);
+    JavaFxUtil.addLabelContextMenus(uiService, mapNameLabel, hpiArchiveLabel, mapDescriptionLabel);
     versionLabel.managedProperty().bind(versionLabel.visibleProperty());
+    mapNameLabel.managedProperty().bind(mapNameLabel.visibleProperty());
     hpiArchiveLabel.managedProperty().bind(hpiArchiveLabel.visibleProperty());
+    mapWindLabel.managedProperty().bind(mapWindLabel.visibleProperty());
+    mapTidalLabel.managedProperty().bind(mapTidalLabel.visibleProperty());
+    mapWaterLabel.managedProperty().bind(mapWaterLabel.visibleProperty());
 
     liveReplayOptionComboBox.getItems().setAll(LiveReplayOption.values());
     LiveReplayOption lastGameLiveReplayOption = preferencesService.getPreferences().getLastGame().getLastGameLiveReplayOption();
@@ -361,7 +373,24 @@ public class CreateGameController implements Controller<Pane> {
       }
     });
     mapPreviewTypeComboBox.getSelectionModel().selectedItemProperty().addListener(
-        (observable, oldValue, newValue) -> setSelectedMap(mapListView.getSelectionModel().getSelectedItem(), newValue, maxPlayersComboBox.getSelectionModel().getSelectedItem()));
+        (observable, oldValue, newValue) -> setSelectedMap(mapListView.getSelectionModel().getSelectedItem(), newValue,
+            mapPreviewOverlayComboBox.getSelectionModel().getSelectedItem(), maxPlayersComboBox.getSelectionModel().getSelectedItem()));
+
+    mapPreviewOverlayComboBox.getItems().setAll(PreviewOverlayType.values());
+    mapPreviewOverlayComboBox.getSelectionModel().select(PreviewOverlayType.NONE);
+    mapPreviewOverlayComboBox.setConverter(new StringConverter<>() {
+      @Override
+      public String toString(PreviewOverlayType previewOverlayType) {
+        return previewOverlayType == null ? "null" : i18n.get(previewOverlayType.getI18nKey());
+      }
+      @Override
+      public PreviewOverlayType fromString(String string) {
+        throw new UnsupportedOperationException("Not supported");
+      }
+    });
+    mapPreviewOverlayComboBox.getSelectionModel().selectedItemProperty().addListener(
+        (observable, oldValue, newValue) -> setSelectedMap(mapListView.getSelectionModel().getSelectedItem(),
+            mapPreviewTypeComboBox.getSelectionModel().getSelectedItem(), newValue, maxPlayersComboBox.getSelectionModel().getSelectedItem()));
 
     maxPlayersComboBox.getItems().setAll(
         IntStream.rangeClosed(2, 10)
@@ -382,7 +411,8 @@ public class CreateGameController implements Controller<Pane> {
       }
     });
     maxPlayersComboBox.getSelectionModel().selectedItemProperty().addListener(
-        (observable, oldValue, newValue) -> setSelectedMap(mapListView.getSelectionModel().getSelectedItem(), mapPreviewTypeComboBox.getSelectionModel().getSelectedItem(), newValue));
+        (observable, oldValue, newValue) -> setSelectedMap(mapListView.getSelectionModel().getSelectedItem(),
+            mapPreviewTypeComboBox.getSelectionModel().getSelectedItem(), mapPreviewOverlayComboBox.getSelectionModel().getSelectedItem(), newValue));
 
     mapSearchTextField.textProperty().addListener(
         (observable, oldValue, newValue) -> setFilteredMapBeansPredicate(newValue));
@@ -727,8 +757,9 @@ public class CreateGameController implements Controller<Pane> {
     mapListView.setCellFactory(param -> new StringListCell<>(MapBean::getMapName));
     ChangeListener<MapBean> selectedMapChangeListener = (observable, oldValue, newValue) -> JavaFxUtil.runLater(() -> {
       PreviewType previewType = mapPreviewTypeComboBox.getSelectionModel().getSelectedItem();
+      PreviewOverlayType previewOverlayType = mapPreviewOverlayComboBox.getSelectionModel().getSelectedItem();
       Integer maxPlayers = maxPlayersComboBox.getSelectionModel().getSelectedItem();
-      setSelectedMap(newValue, previewType, maxPlayers);
+      setSelectedMap(newValue, previewType, previewOverlayType, maxPlayers);
     });
     mapListView.getSelectionModel().selectedItemProperty().addListener(selectedMapChangeListener);
     selectedMapChangeListener.changed(null, null, mapListView.getSelectionModel().selectedItemProperty().getValue());
@@ -838,40 +869,46 @@ public class CreateGameController implements Controller<Pane> {
     rankedMapPoolsAvailableProperty.bind(Bindings.isNotEmpty(mapPoolListView.getItems()));
   }
 
-  protected void setSelectedMap(MapBean newValue, PreviewType previewType, int maxNumPlayers) {
+  protected void setSelectedMap(MapBean newValue, PreviewType previewType, PreviewOverlayType previewOverlayType, int maxNumPlayers) {
     JavaFxUtil.assertApplicationThread();
 
     if (newValue == null) {
       mapPreview.setVisible(false);
+      setMapPreviewPaneBackground(mapPreviewPane, null);
+      setMapPreviewPaneBackground(mapPreviewOverlayPane, null);
       return;
     }
     mapPreview.setVisible(true);
+    previewType = Optional.ofNullable(previewType).orElse(PreviewType.MINI);
+    previewOverlayType = Optional.ofNullable(previewOverlayType).orElse(PreviewOverlayType.NONE);
 
     preferencesService.getPreferences().getLastGame().setLastMap(newValue.getMapName());
     preferencesService.storeInBackground();
 
     String activeMod;
-    if (featuredModListView.getFocusModel().getFocusedItem() != null) {
-      activeMod = featuredModListView.getFocusModel().getFocusedItem().getTechnicalName();
+    if (featuredModListView.getSelectionModel().getSelectedItem() != null) {
+      activeMod = featuredModListView.getSelectionModel().getSelectedItem().getTechnicalName();
     }
     else {
       activeMod = preferencesService.getPreferences().getLastGame().getLastGameType();
     }
+    MapBean mapDetails = mapService.getMapLocallyFromMapBean(activeMod, newValue).orElse(newValue);
+    String previewMapName = mapDetails.getMapName();
 
-    Image preview = mapService.loadPreview(activeMod, newValue.getMapName(), previewType, maxNumPlayers);
-    mapPreviewPane.setBackground(new Background(new BackgroundImage(preview, NO_REPEAT, NO_REPEAT, CENTER,
-        new BackgroundSize(BackgroundSize.AUTO, BackgroundSize.AUTO, false, false, true, false))));
+    Image preview = mapService.loadPreview(activeMod, previewMapName, previewType, maxNumPlayers);
+    setMapPreviewPaneBackground(mapPreviewPane, preview);
+    Image previewOverlay = mapService.loadOverlayPreview(activeMod, previewMapName, previewOverlayType, maxNumPlayers);
+    setMapPreviewPaneBackground(mapPreviewOverlayPane, previewOverlay);
 
-    MapSize mapSize = newValue.getSize();
+    MapSize mapSize = mapDetails.getSize();
     mapSizeLabel.setText(i18n.get("mapPreview.size", mapSize.getWidthInKm(), mapSize.getHeightInKm()));
-    mapPlayersLabel.setText(i18n.number(newValue.getPlayers()));
-    mapDescriptionLabel.setText(Optional.ofNullable(newValue.getDescription())
-        .map(Strings::emptyToNull)
-        .map(FaStrings::removeLocalizationTag)
-        .orElseGet(() -> i18n.get("map.noDescriptionAvailable")));
+    setSignedMapStatLabel(mapWindLabel, formatWindSpeedRange(mapDetails.getWind()), "mapPreview.wind");
+    setSignedMapStatLabel(mapTidalLabel, mapDetails.getTidal(), "mapPreview.tidal");
+    setWaterPercentLabel(mapDetails);
+    mapPlayersLabel.setText(i18n.number(mapDetails.getPlayers()));
+    mapDescriptionLabel.setText(formatMapDescription(mapDetails.getDescription()));
 
-    hpiArchiveLabel.setText(newValue.getHpiArchiveName());
-    hpiArchiveLabel.setVisible(true);
+    setMapTitleLabels(mapDetails);
 
     ComparableVersion mapVersion = newValue.getVersion();
     if (mapVersion == null) {
@@ -879,6 +916,91 @@ public class CreateGameController implements Controller<Pane> {
     } else {
       versionLabel.setText(i18n.get("map.versionFormat", mapVersion));
     }
+  }
+
+  private String formatMapDescription(String description) {
+    return Optional.ofNullable(description)
+        .map(Strings::emptyToNull)
+        .map(FaStrings::removeLocalizationTag)
+        .map(value -> value.replaceAll("\\s+", " ").trim())
+        .orElseGet(() -> i18n.get("map.noDescriptionAvailable"));
+  }
+
+  private void setMapPreviewPaneBackground(Pane pane, Image image) {
+    if (image == null) {
+      pane.setBackground(null);
+      return;
+    }
+
+    pane.setBackground(new Background(new BackgroundImage(image, NO_REPEAT, NO_REPEAT, CENTER,
+        new BackgroundSize(BackgroundSize.AUTO, BackgroundSize.AUTO, false, false, true, false))));
+  }
+
+  private void setSignedMapStatLabel(Label label, String value, String i18nKey) {
+    String displayValue = withPositiveSign(value);
+    label.setVisible(!displayValue.isEmpty());
+    if (!displayValue.isEmpty()) {
+      label.setText(i18n.get(i18nKey, displayValue));
+    }
+  }
+
+  private void setMapTitleLabels(MapBean map) {
+    String archiveName = Strings.nullToEmpty(map.getHpiArchiveName()).trim();
+    String mapName = Strings.nullToEmpty(map.getMapName()).trim();
+
+    mapNameLabel.setText(mapName.isEmpty() ? archiveName : mapName);
+    mapNameLabel.setVisible(!mapNameLabel.getText().isEmpty());
+    hpiArchiveLabel.setText(archiveName);
+    hpiArchiveLabel.setVisible(!archiveName.isEmpty() && !mapName.isEmpty());
+  }
+
+  private void setWaterPercentLabel(MapBean map) {
+    int waterPercentage = map.getWaterPercentage();
+    mapWaterLabel.setVisible(waterPercentage >= 0);
+    if (waterPercentage >= 0) {
+      mapWaterLabel.setText(i18n.get("mapPreview.water", waterPercentage));
+    }
+  }
+
+  private String formatWindSpeedRange(String value) {
+    if (value == null || value.isBlank()) {
+      return "";
+    }
+
+    String trimmed = value.trim();
+    String[] parts = trimmed.split("-", 2);
+    if (parts.length != 2) {
+      return trimmed;
+    }
+
+    String minWind = formatWindSpeed(parts[0]);
+    String maxWind = formatWindSpeed(parts[1]);
+    if (minWind.isEmpty() || maxWind.isEmpty()) {
+      return trimmed;
+    }
+
+    return minWind.equals(maxWind) ? minWind : minWind + "-" + maxWind;
+  }
+
+  private String formatWindSpeed(String value) {
+    try {
+      double wind = Double.parseDouble(value.trim().replace("+", "")) / WIND_SPEED_DISPLAY_SCALE;
+      return Long.toString(Math.round(wind));
+    } catch (NumberFormatException e) {
+      return "";
+    }
+  }
+
+  private String withPositiveSign(String value) {
+    if (value == null || value.isBlank()) {
+      return "";
+    }
+
+    String trimmed = value.trim();
+    if (trimmed.startsWith("+") || trimmed.startsWith("-")) {
+      return trimmed;
+    }
+    return "+" + trimmed;
   }
 
   private void initFeaturedModList() {
@@ -993,7 +1115,7 @@ public class CreateGameController implements Controller<Pane> {
     }
 
     if (mapListView.getItems().isEmpty()) {
-      setSelectedMap(null, null, 10);
+      setSelectedMap(null, null, null, 10);
     }
     else {
       mapListView.getSelectionModel().selectFirst();
@@ -1266,6 +1388,7 @@ public class CreateGameController implements Controller<Pane> {
       setSelectedMap(
           mapListView.getSelectionModel().getSelectedItem(),
           mapPreviewTypeComboBox.getSelectionModel().getSelectedItem(),
+          mapPreviewOverlayComboBox.getSelectionModel().getSelectedItem(),
           maxPlayersComboBox.getSelectionModel().getSelectedItem());
     });
     contextMenu.getItems().add(menuItem);
@@ -1287,6 +1410,7 @@ public class CreateGameController implements Controller<Pane> {
           JavaFxUtil.runLater(() -> setSelectedMap(
               mapListView.getSelectionModel().getSelectedItem(),
               mapPreviewTypeComboBox.getSelectionModel().getSelectedItem(),
+              mapPreviewOverlayComboBox.getSelectionModel().getSelectedItem(),
               maxPlayersComboBox.getSelectionModel().getSelectedItem()));
         });
   }

--- a/src/main/java/com/faforever/client/map/MapBean.java
+++ b/src/main/java/com/faforever/client/map/MapBean.java
@@ -39,7 +39,6 @@ public class MapBean implements Comparable<MapBean> {
   private final IntegerProperty players;
   private final StringProperty wind;
   private final StringProperty tidal;
-  private final IntegerProperty waterPercentage;
   private final ObjectProperty<MapSize> size;
   private final ObjectProperty<ComparableVersion> version;
   private CompletableFuture<String> crcFuture;
@@ -67,7 +66,6 @@ public class MapBean implements Comparable<MapBean> {
     players = new SimpleIntegerProperty();
     wind = new SimpleStringProperty("");
     tidal = new SimpleStringProperty("");
-    waterPercentage = new SimpleIntegerProperty(-1);
     size = new SimpleObjectProperty<>();
     version = new SimpleObjectProperty<>();
     thumbnailUrl = new SimpleObjectProperty<>();
@@ -264,18 +262,6 @@ public class MapBean implements Comparable<MapBean> {
 
   public StringProperty tidalProperty() {
     return tidal;
-  }
-
-  public int getWaterPercentage() {
-    return waterPercentage.get();
-  }
-
-  public void setWaterPercentage(int waterPercentage) {
-    this.waterPercentage.set(waterPercentage);
-  }
-
-  public IntegerProperty waterPercentageProperty() {
-    return waterPercentage;
   }
 
   @Nullable

--- a/src/main/java/com/faforever/client/map/MapBean.java
+++ b/src/main/java/com/faforever/client/map/MapBean.java
@@ -37,6 +37,9 @@ public class MapBean implements Comparable<MapBean> {
   private final StringProperty description;
   private final IntegerProperty downloads;
   private final IntegerProperty players;
+  private final StringProperty wind;
+  private final StringProperty tidal;
+  private final IntegerProperty waterPercentage;
   private final ObjectProperty<MapSize> size;
   private final ObjectProperty<ComparableVersion> version;
   private CompletableFuture<String> crcFuture;
@@ -62,6 +65,9 @@ public class MapBean implements Comparable<MapBean> {
     numberOfPlays = new SimpleIntegerProperty(0);
     downloads = new SimpleIntegerProperty();
     players = new SimpleIntegerProperty();
+    wind = new SimpleStringProperty("");
+    tidal = new SimpleStringProperty("");
+    waterPercentage = new SimpleIntegerProperty(-1);
     size = new SimpleObjectProperty<>();
     version = new SimpleObjectProperty<>();
     thumbnailUrl = new SimpleObjectProperty<>();
@@ -234,6 +240,42 @@ public class MapBean implements Comparable<MapBean> {
 
   public IntegerProperty playersProperty() {
     return players;
+  }
+
+  public String getWind() {
+    return wind.get();
+  }
+
+  public void setWind(String wind) {
+    this.wind.set(wind);
+  }
+
+  public StringProperty windProperty() {
+    return wind;
+  }
+
+  public String getTidal() {
+    return tidal.get();
+  }
+
+  public void setTidal(String tidal) {
+    this.tidal.set(tidal);
+  }
+
+  public StringProperty tidalProperty() {
+    return tidal;
+  }
+
+  public int getWaterPercentage() {
+    return waterPercentage.get();
+  }
+
+  public void setWaterPercentage(int waterPercentage) {
+    this.waterPercentage.set(waterPercentage);
+  }
+
+  public IntegerProperty waterPercentageProperty() {
+    return waterPercentage;
   }
 
   @Nullable

--- a/src/main/java/com/faforever/client/map/MapDetailController.java
+++ b/src/main/java/com/faforever/client/map/MapDetailController.java
@@ -244,10 +244,6 @@ public class MapDetailController implements Controller<Node> {
       mapStats += "  " + i18n.get("mapPreview.tidal", tidal);
     }
 
-    if (map.getWaterPercentage() >= 0) {
-      mapStats += "  " + i18n.get("mapPreview.water", map.getWaterPercentage());
-    }
-
     return mapStats;
   }
 

--- a/src/main/java/com/faforever/client/map/MapDetailController.java
+++ b/src/main/java/com/faforever/client/map/MapDetailController.java
@@ -52,6 +52,7 @@ import java.util.concurrent.CompletableFuture;
 @Slf4j
 @RequiredArgsConstructor
 public class MapDetailController implements Controller<Node> {
+  private static final double WIND_SPEED_DISPLAY_SCALE = 166.6;
 
   private final MapService mapService;
   private final NotificationService notificationService;
@@ -178,7 +179,7 @@ public class MapDetailController implements Controller<Node> {
     mapHpiArchiveNameLabel.setText(map.getHpiArchiveName());
 
     MapSize mapSize = map.getSize();
-    dimensionsLabel.setText(i18n.get("mapPreview.size", mapSize.getWidthInKm(), mapSize.getHeightInKm()));
+    dimensionsLabel.setText(getMapSizeAndEnvironmentText(map, mapSize));
 
     LocalDateTime createTime = map.getCreateTime();
     dateLabel.setText(timeService.asDate(createTime));
@@ -229,6 +230,66 @@ public class MapDetailController implements Controller<Node> {
       mapService.isInstalled(modTechnical, map.getMapName(), map.getCrcValue()).thenAccept(
           isInstalled -> JavaFxUtil.runLater(() -> setInstalled(isInstalled)));
     }
+  }
+
+  private String getMapSizeAndEnvironmentText(MapBean map, MapSize mapSize) {
+    String mapStats = i18n.get("mapPreview.size", mapSize.getWidthInKm(), mapSize.getHeightInKm());
+    String wind = withPositiveSign(formatWindSpeedRange(map.getWind()));
+    if (!wind.isEmpty()) {
+      mapStats += "  " + i18n.get("mapPreview.wind", wind);
+    }
+
+    String tidal = withPositiveSign(map.getTidal());
+    if (!tidal.isEmpty()) {
+      mapStats += "  " + i18n.get("mapPreview.tidal", tidal);
+    }
+
+    if (map.getWaterPercentage() >= 0) {
+      mapStats += "  " + i18n.get("mapPreview.water", map.getWaterPercentage());
+    }
+
+    return mapStats;
+  }
+
+  private String formatWindSpeedRange(String value) {
+    if (value == null || value.isBlank()) {
+      return "";
+    }
+
+    String trimmed = value.trim();
+    String[] parts = trimmed.split("-", 2);
+    if (parts.length != 2) {
+      return trimmed;
+    }
+
+    String minWind = formatWindSpeed(parts[0]);
+    String maxWind = formatWindSpeed(parts[1]);
+    if (minWind.isEmpty() || maxWind.isEmpty()) {
+      return trimmed;
+    }
+
+    return minWind.equals(maxWind) ? minWind : minWind + "-" + maxWind;
+  }
+
+  private String formatWindSpeed(String value) {
+    try {
+      double wind = Double.parseDouble(value.trim().replace("+", "")) / WIND_SPEED_DISPLAY_SCALE;
+      return Long.toString(Math.round(wind));
+    } catch (NumberFormatException e) {
+      return "";
+    }
+  }
+
+  private String withPositiveSign(String value) {
+    if (value == null || value.isBlank()) {
+      return "";
+    }
+
+    String trimmed = value.trim();
+    if (trimmed.startsWith("+") || trimmed.startsWith("-")) {
+      return trimmed;
+    }
+    return "+" + trimmed;
   }
 
   @VisibleForTesting

--- a/src/main/java/com/faforever/client/map/MapService.java
+++ b/src/main/java/com/faforever/client/map/MapService.java
@@ -97,7 +97,6 @@ import static com.faforever.client.fa.MapTool.MAP_DETAIL_COLUMN_NAME;
 import static com.faforever.client.fa.MapTool.MAP_DETAIL_COLUMN_NUM_PLAYERS;
 import static com.faforever.client.fa.MapTool.MAP_DETAIL_COLUMN_SIZE;
 import static com.faforever.client.fa.MapTool.MAP_DETAIL_COLUMN_TIDAL;
-import static com.faforever.client.fa.MapTool.MAP_DETAIL_COLUMN_WATER_PERCENT;
 import static com.faforever.client.fa.MapTool.MAP_DETAIL_COLUMN_WIND;
 import static com.faforever.client.util.LinkOrCopy.linkOrCopyWithBackup;
 import static com.github.nocatch.NoCatch.noCatch;
@@ -505,7 +504,6 @@ public class MapService implements InitializingBean, DisposableBean {
     int players = 10;
     String wind = "";
     String tidal = "";
-    int waterPercentage = -1;
 
     try {
       if (mapDetails != null) {
@@ -516,7 +514,6 @@ public class MapService implements InitializingBean, DisposableBean {
         players = parseMapDetailInteger(mapDetailValue(mapDetails, MAP_DETAIL_COLUMN_NUM_PLAYERS), players);
         wind = mapDetailValue(mapDetails, MAP_DETAIL_COLUMN_WIND);
         tidal = mapDetailValue(mapDetails, MAP_DETAIL_COLUMN_TIDAL);
-        waterPercentage = parseMapDetailInteger(mapDetailValue(mapDetails, MAP_DETAIL_COLUMN_WATER_PERCENT), waterPercentage);
       }
       else {
         logger.warn("null map details for map: {}", mapName);
@@ -541,7 +538,6 @@ public class MapService implements InitializingBean, DisposableBean {
     mapBean.setPlayers(players);
     mapBean.setWind(wind);
     mapBean.setTidal(tidal);
-    mapBean.setWaterPercentage(waterPercentage);
     mapBean.setType(Type.SKIRMISH);
 
     if (!"00000000".equals(crc)) {

--- a/src/main/java/com/faforever/client/map/MapService.java
+++ b/src/main/java/com/faforever/client/map/MapService.java
@@ -75,6 +75,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -93,7 +94,11 @@ import static com.faforever.client.fa.MapTool.MAP_DETAIL_COLUMN_ARCHIVE;
 import static com.faforever.client.fa.MapTool.MAP_DETAIL_COLUMN_CRC;
 import static com.faforever.client.fa.MapTool.MAP_DETAIL_COLUMN_DESCRIPTION;
 import static com.faforever.client.fa.MapTool.MAP_DETAIL_COLUMN_NAME;
+import static com.faforever.client.fa.MapTool.MAP_DETAIL_COLUMN_NUM_PLAYERS;
 import static com.faforever.client.fa.MapTool.MAP_DETAIL_COLUMN_SIZE;
+import static com.faforever.client.fa.MapTool.MAP_DETAIL_COLUMN_TIDAL;
+import static com.faforever.client.fa.MapTool.MAP_DETAIL_COLUMN_WATER_PERCENT;
+import static com.faforever.client.fa.MapTool.MAP_DETAIL_COLUMN_WIND;
 import static com.faforever.client.util.LinkOrCopy.linkOrCopyWithBackup;
 import static com.github.nocatch.NoCatch.noCatch;
 import static com.google.common.net.UrlEscapers.urlFragmentEscaper;
@@ -459,6 +464,36 @@ public class MapService implements InitializingBean, DisposableBean {
   }
 
   static final Pattern MAP_SIZE_FROM_DESCRIPTION_REGEX = Pattern.compile("([0-9]+\\s?[xX]\\s?[0-9]+)[\\s\\.].*");
+
+  private static String mapDetailValue(String[] mapDetails, int index) {
+    return mapDetailValue(mapDetails, index, "");
+  }
+
+  private static String mapDetailValue(String[] mapDetails, int index, String defaultValue) {
+    return mapDetails.length > index ? mapDetails[index] : defaultValue;
+  }
+
+  private static int parseMapDetailInteger(String value, int defaultValue) {
+    if (value == null || value.isBlank()) {
+      return defaultValue;
+    }
+
+    String[] parts = value.split(",");
+    for (int index = parts.length - 1; index >= 0; index--) {
+      String number = parts[index].trim().replaceAll("[^0-9-]", "");
+      if (number.isEmpty()) {
+        continue;
+      }
+
+      try {
+        return Integer.parseInt(number);
+      } catch (NumberFormatException ignored) {
+      }
+    }
+
+    return defaultValue;
+  }
+
   @NotNull
   public MapBean readMap(String mapName, @Nullable String [] mapDetails, @Nullable Function<Void, String> getInstalledMapCrc) {
     MapBean mapBean = new MapBean();
@@ -467,13 +502,21 @@ public class MapService implements InitializingBean, DisposableBean {
     String description = mapName;
     String mapSizeStr = "16 x 16";
     String crc = "00000000";
+    int players = 10;
+    String wind = "";
+    String tidal = "";
+    int waterPercentage = -1;
 
     try {
       if (mapDetails != null) {
-        archiveName = mapDetails[MAP_DETAIL_COLUMN_ARCHIVE];
-        description = mapDetails[MAP_DETAIL_COLUMN_DESCRIPTION];
-        mapSizeStr = mapDetails[MAP_DETAIL_COLUMN_SIZE];
-        crc = mapDetails[MAP_DETAIL_COLUMN_CRC];
+        archiveName = mapDetailValue(mapDetails, MAP_DETAIL_COLUMN_ARCHIVE, archiveName);
+        description = mapDetailValue(mapDetails, MAP_DETAIL_COLUMN_DESCRIPTION, description);
+        mapSizeStr = mapDetailValue(mapDetails, MAP_DETAIL_COLUMN_SIZE, mapSizeStr);
+        crc = mapDetailValue(mapDetails, MAP_DETAIL_COLUMN_CRC, crc);
+        players = parseMapDetailInteger(mapDetailValue(mapDetails, MAP_DETAIL_COLUMN_NUM_PLAYERS), players);
+        wind = mapDetailValue(mapDetails, MAP_DETAIL_COLUMN_WIND);
+        tidal = mapDetailValue(mapDetails, MAP_DETAIL_COLUMN_TIDAL);
+        waterPercentage = parseMapDetailInteger(mapDetailValue(mapDetails, MAP_DETAIL_COLUMN_WATER_PERCENT), waterPercentage);
       }
       else {
         logger.warn("null map details for map: {}", mapName);
@@ -495,7 +538,10 @@ public class MapService implements InitializingBean, DisposableBean {
     mapBean.setMapName(mapName);
     mapBean.setDescription(description.replaceAll("[ ][ ]+", "\n"));  // some maps insert spaces into description to move to new line when displayed in TA lobby
     mapBean.setHpiArchiveName(archiveName);
-    mapBean.setPlayers(10);
+    mapBean.setPlayers(players);
+    mapBean.setWind(wind);
+    mapBean.setTidal(tidal);
+    mapBean.setWaterPercentage(waterPercentage);
     mapBean.setType(Type.SKIRMISH);
 
     if (!"00000000".equals(crc)) {
@@ -538,8 +584,54 @@ public class MapService implements InitializingBean, DisposableBean {
   }
 
   public Optional<MapBean> getMapLocallyFromName(String modTechnical, String mapName) {
-    logger.debug("Trying to find map '{}' locally", mapName);
-    return Optional.ofNullable(installations.getOrDefault(modTechnical, new Installation(modTechnical)).mapsByName.get(mapName));
+    return getMapLocallyFromNameOrArchive(modTechnical, mapName, null);
+  }
+
+  public Optional<MapBean> getMapLocallyFromNameOrArchive(String modTechnical, @Nullable String mapName, @Nullable String archiveName) {
+    logger.debug("Trying to find map '{}' / archive '{}' locally", mapName, archiveName);
+    Installation installation = getInstallation(modTechnical);
+    if (mapName != null) {
+      MapBean map = installation.mapsByName.get(mapName);
+      if (map != null) {
+        return Optional.of(map);
+      }
+    }
+
+    return installation.maps.stream()
+        .filter(installedMap -> isSameMapIdentifier(installedMap.getMapName(), mapName)
+            || isSameMapIdentifier(installedMap.getMapName(), archiveName)
+            || isSameMapIdentifier(installedMap.getHpiArchiveName(), mapName)
+            || isSameMapIdentifier(installedMap.getHpiArchiveName(), archiveName))
+        .findFirst();
+  }
+
+  public Optional<MapBean> getMapLocallyFromMapBean(String modTechnical, MapBean map) {
+    return getMapLocallyFromNameOrArchive(modTechnical, map.getMapName(), map.getHpiArchiveName());
+  }
+
+  private boolean isSameMapIdentifier(@Nullable String left, @Nullable String right) {
+    String normalizedLeft = normalizeMapIdentifier(left);
+    String normalizedRight = normalizeMapIdentifier(right);
+    return normalizedLeft != null && normalizedLeft.equals(normalizedRight);
+  }
+
+  @Nullable
+  private String normalizeMapIdentifier(@Nullable String value) {
+    if (value == null) {
+      return null;
+    }
+
+    String normalized = value.trim();
+    if (normalized.isEmpty()) {
+      return null;
+    }
+
+    String lowerCase = normalized.toLowerCase(Locale.ROOT);
+    if (lowerCase.endsWith(".ufo") || lowerCase.endsWith(".hpi") || lowerCase.endsWith(".ccx")) {
+      normalized = normalized.substring(0, normalized.length() - 4);
+    }
+    normalized = normalized.replaceFirst("(?i)([._ -]v\\d+)$", "");
+    return normalized.toLowerCase(Locale.ROOT);
   }
 
   public boolean isOfficialMap(String mapName) {
@@ -974,10 +1066,22 @@ public class MapService implements InitializingBean, DisposableBean {
   }
 
   public void generatePreview(String modTechnical, String mapName, Path cachedFile, PreviewType previewType, int maxPositions) {
-    if (previewType == PreviewType.MINI && Files.exists(cachedFile)) {
+    if (Files.exists(cachedFile)) {
       return;
     }
 
+    generatePreview(modTechnical, mapName, cachedFile, previewType.getToolName(), maxPositions, false);
+  }
+
+  public void generateOverlayPreview(String modTechnical, String mapName, Path cachedFile, PreviewOverlayType previewOverlayType, int maxPositions) {
+    if (previewOverlayType == null || previewOverlayType == PreviewOverlayType.NONE || Files.exists(cachedFile)) {
+      return;
+    }
+
+    generatePreview(modTechnical, mapName, cachedFile, previewOverlayType.getToolName(), maxPositions, true);
+  }
+
+  private void generatePreview(String modTechnical, String mapName, Path cachedFile, String previewToolName, int maxPositions, boolean overlay) {
     Path gamePath = preferencesService.getTotalAnnihilation(modTechnical).getInstalledPath();
     if (gamePath == null) {
       gamePath = preferencesService.getTotalAnnihilation(KnownFeaturedMod.DEFAULT.getTechnicalName()).getInstalledPath();
@@ -1008,7 +1112,11 @@ public class MapService implements InitializingBean, DisposableBean {
     }
 
     try {
-      MapTool.generatePreview(gamePath, modGp3FileName, mapName, cachedFile.getParent().getParent(), previewType, maxPositions);
+      if (overlay) {
+        MapTool.generateOverlayPreview(gamePath, modGp3FileName, mapName, cachedFile.getParent().getParent(), PreviewOverlayType.fromToolName(previewToolName), maxPositions);
+      } else {
+        MapTool.generatePreview(gamePath, modGp3FileName, mapName, cachedFile.getParent().getParent(), PreviewType.fromToolName(previewToolName), maxPositions);
+      }
     }
     catch (IOException e) {
       notifyBadMapTool(e);
@@ -1049,11 +1157,35 @@ public class MapService implements InitializingBean, DisposableBean {
     return assetService.loadAndCacheImage(url, cacheDir, null);
   }
 
+  @Nullable
+  public Image loadOverlayPreview(String modTechnical, String mapName, PreviewOverlayType previewOverlayType, int maxPositions) {
+    if (previewOverlayType == null || previewOverlayType == PreviewOverlayType.NONE) {
+      return null;
+    }
+
+    Path cacheDir = preferencesService.getCacheDirectory().resolve("maps").resolve(previewOverlayType.getFolderName(maxPositions));
+    Path cachedFile = cacheDir.resolve(mapName + ".png");
+    generateOverlayPreview(modTechnical, mapName, cachedFile, previewOverlayType, maxPositions);
+    if (!Files.exists(cachedFile)) {
+      return null;
+    }
+
+    return new Image(noCatch(() -> cachedFile.toUri().toURL().toExternalForm()));
+  }
+
   @CacheEvict(value = CacheNames.MAP_PREVIEW, allEntries = true)
   public void resetPreviews(String mapName) {
     for (PreviewType previewType: PreviewType.values()) {
       for (int maxPositions=2; maxPositions<=10; ++maxPositions) {
         resetPreview(getPreviewUrl(mapName, mapPreviewUrlFormat, previewType), previewType, maxPositions);
+      }
+    }
+    for (PreviewOverlayType previewOverlayType : PreviewOverlayType.values()) {
+      if (previewOverlayType == PreviewOverlayType.NONE) {
+        continue;
+      }
+      for (int maxPositions=2; maxPositions<=10; ++maxPositions) {
+        resetOverlayPreview(mapName, previewOverlayType, maxPositions);
       }
     }
   }
@@ -1065,6 +1197,17 @@ public class MapService implements InitializingBean, DisposableBean {
     String cachedFilename = urlString.substring(urlString.lastIndexOf('/') + 1);
     Path cacheSubFolder = Paths.get("maps").resolve(previewType.getFolderName(maxPositions));
     Path cachedFile = preferencesService.getCacheDirectory().resolve(cacheSubFolder).resolve(cachedFilename);
+    try {
+      Files.deleteIfExists(cachedFile);
+    } catch (IOException e) {
+      logger.error("Unable to delete cached preview {}", cachedFile);
+    }
+  }
+
+  private void resetOverlayPreview(String mapName, PreviewOverlayType previewOverlayType, int maxPositions) {
+    Path cachedFile = preferencesService.getCacheDirectory()
+        .resolve(Paths.get("maps").resolve(previewOverlayType.getFolderName(maxPositions)))
+        .resolve(mapName + ".png");
     try {
       Files.deleteIfExists(cachedFile);
     } catch (IOException e) {
@@ -1183,11 +1326,8 @@ public class MapService implements InitializingBean, DisposableBean {
   public enum PreviewType {
     // These must match the preview URLs
     MINI("mini"),
-    POSITIONS("positions"),
-    MEXES("mexes"),
-    GEOS("geos"),
-    ROCKS("rocks"),
-    TREES("trees");
+    HEIGHTMAP("heightmap"),
+    HEIGHTMAP_WATER("heightmap-water");
 
     final private String folderName;
 
@@ -1198,6 +1338,44 @@ public class MapService implements InitializingBean, DisposableBean {
     public String getI18nKey() {
       return switch (this) {
         case MINI -> "map.previewType.minimap";
+        case HEIGHTMAP -> "map.previewType.heightmap";
+        case HEIGHTMAP_WATER -> "map.previewType.heightmapWater";
+      };
+    }
+
+    public String getToolName() {
+      return folderName;
+    }
+
+    public static PreviewType fromToolName(String toolName) {
+      return Arrays.stream(values())
+          .filter(previewType -> previewType.getToolName().equals(toolName))
+          .findFirst()
+          .orElseThrow(() -> new IllegalArgumentException("Unknown preview type: " + toolName));
+    }
+
+    String getFolderName(int maxNumPlayers) {
+      return this.folderName;
+    }
+  }
+
+  public enum PreviewOverlayType {
+    NONE(null),
+    POSITIONS("positions-overlay"),
+    MEXES("mexes-overlay"),
+    GEOS("geos-overlay"),
+    ROCKS("rocks-overlay"),
+    TREES("trees-overlay");
+
+    final private String folderName;
+
+    PreviewOverlayType(String folderName) {
+      this.folderName = folderName;
+    }
+
+    public String getI18nKey() {
+      return switch (this) {
+        case NONE -> "map.previewOverlay.none";
         case POSITIONS -> "map.previewType.Positions";
         case MEXES -> "map.previewType.metalPatches";
         case GEOS -> "map.previewType.geoVents";
@@ -1206,10 +1384,18 @@ public class MapService implements InitializingBean, DisposableBean {
       };
     }
 
+    public String getToolName() {
+      return folderName;
+    }
+
+    public static PreviewOverlayType fromToolName(String toolName) {
+      return Arrays.stream(values())
+          .filter(previewOverlayType -> Objects.equals(previewOverlayType.getToolName(), toolName))
+          .findFirst()
+          .orElseThrow(() -> new IllegalArgumentException("Unknown preview overlay type: " + toolName));
+    }
+
     String getFolderName(int maxNumPlayers) {
-      if (this == PreviewType.MINI) {
-        return this.folderName;
-      }
       return String.format("%s_%s", this.folderName, maxNumPlayers);
     }
   }

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -894,6 +894,12 @@ map.preview.update = Update Preview
 
 # Name of a map preview type: shows only its minimap (the zoomed-out overview of the map)
 map.previewType.minimap = Minimap
+# Name of a map preview type: shows only the terrain heightmap
+map.previewType.heightmap = Heightmap
+# Name of a map preview type: shows terrain heightmap with water highlighted
+map.previewType.heightmapWater = Heightmap + water
+# Name of a map preview overlay option: shows no overlay
+map.previewOverlay.none = None
 # Name of a map preview type: shows the player start positions
 map.previewType.Positions = Positions
 # Name of a map preview type: shows the distribution of metal extraction locations
@@ -955,6 +961,12 @@ mapDownloadTask.title = Downloading map pack ''{0}'' ({1}MB)
 
 # Field: preview dimensions of a map
 mapPreview.size = {0,number,\#} x {1,number,\#}
+# Field: preview wind speed range of a map
+mapPreview.wind = Wind:{0}
+# Field: preview tidal strength of a map
+mapPreview.tidal = Tidal:{0}
+# Field: preview percent of a map covered by water
+mapPreview.water = Water: {0,number,\#}%
 
 # Background task title: downloading replay by ID
 mapReplayTask.title = Downloading replay {0}

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -966,7 +966,6 @@ mapPreview.wind = Wind:{0}
 # Field: preview tidal strength of a map
 mapPreview.tidal = Tidal:{0}
 # Field: preview percent of a map covered by water
-mapPreview.water = Water: {0,number,\#}%
 
 # Background task title: downloading replay by ID
 mapReplayTask.title = Downloading replay {0}

--- a/src/main/resources/i18n/messages_ca.properties
+++ b/src/main/resources/i18n/messages_ca.properties
@@ -1548,3 +1548,6 @@ manualTeams.autoFill=Emplenament automàtic
 manualTeams.autoFill.tooltip=Col·loca els jugadors sense assignar en equips equilibrats al voltant de la teva selecció fixada
 manualTeams.maxPlayers=Jugadors màx.
 game.pinnedTeamBadge.tooltip=Fixat a Equip {0,number,#} pel host per a +autoteam
+map.previewType.heightmap = Mapa d'alçades
+map.previewType.heightmapWater = Mapa d'alçades + aigua
+map.previewOverlay.none = Cap

--- a/src/main/resources/i18n/messages_cs.properties
+++ b/src/main/resources/i18n/messages_cs.properties
@@ -2199,3 +2199,6 @@ manualTeams.autoFill = Automatické doplnění
 manualTeams.autoFill.tooltip = Rozmístit nepřiřazené hráče do vyvážených týmů kolem vašeho zafixovaného výběru
 manualTeams.maxPlayers = Max. hráčů
 game.pinnedTeamBadge.tooltip = Připnuto k týmu {0,number,#} hostitelem pro +autoteam
+map.previewType.heightmap = Výšková mapa
+map.previewType.heightmapWater = Výšková mapa + voda
+map.previewOverlay.none = Žádné

--- a/src/main/resources/i18n/messages_de.properties
+++ b/src/main/resources/i18n/messages_de.properties
@@ -2197,3 +2197,6 @@ manualTeams.autoFill = Auto-Füllen
 manualTeams.autoFill.tooltip = Nicht zugewiesene Spieler ausgewogen auf die Teams verteilen, rund um deine festgelegte Auswahl
 manualTeams.maxPlayers = Max. Spieler
 game.pinnedTeamBadge.tooltip = Vom Host für +autoteam an Team {0,number,#} angeheftet
+map.previewType.heightmap = Höhenkarte
+map.previewType.heightmapWater = Höhenkarte + Wasser
+map.previewOverlay.none = Keine

--- a/src/main/resources/i18n/messages_es.properties
+++ b/src/main/resources/i18n/messages_es.properties
@@ -2199,3 +2199,6 @@ manualTeams.autoFill = Autorrelleno
 manualTeams.autoFill.tooltip = Coloca a los jugadores sin asignar en equipos equilibrados en torno a tu selección fijada
 manualTeams.maxPlayers = Jugadores máx.
 game.pinnedTeamBadge.tooltip = Fijado al Equipo {0,number,#} por el anfitrión para +autoteam
+map.previewType.heightmap = Mapa de altura
+map.previewType.heightmapWater = Mapa de altura + agua
+map.previewOverlay.none = Ninguno

--- a/src/main/resources/i18n/messages_fr.properties
+++ b/src/main/resources/i18n/messages_fr.properties
@@ -2201,3 +2201,6 @@ manualTeams.autoFill = Remplissage auto
 manualTeams.autoFill.tooltip = Répartir les joueurs non assignés dans des équipes équilibrées autour de vos choix fixés
 manualTeams.maxPlayers = Joueurs max
 game.pinnedTeamBadge.tooltip = Épinglé en Équipe {0,number,#} par le host pour +autoteam
+map.previewType.heightmap = Carte de hauteur
+map.previewType.heightmapWater = Carte de hauteur + eau
+map.previewOverlay.none = Aucun

--- a/src/main/resources/i18n/messages_he.properties
+++ b/src/main/resources/i18n/messages_he.properties
@@ -1549,3 +1549,6 @@ manualTeams.autoFill=מילוי אוטומטי
 manualTeams.autoFill.tooltip=שבץ שחקנים לא משויכים בקבוצות מאוזנות סביב הבחירות המקובעות שלך
 manualTeams.maxPlayers=מקסימום שחקנים
 game.pinnedTeamBadge.tooltip=מקובע לקבוצה {0,number,#} על ידי המארח עבור +autoteam
+map.previewType.heightmap = מפת גבהים
+map.previewType.heightmapWater = מפת גבהים + מים
+map.previewOverlay.none = ללא

--- a/src/main/resources/i18n/messages_it.properties
+++ b/src/main/resources/i18n/messages_it.properties
@@ -2200,3 +2200,6 @@ manualTeams.autoFill = Riempimento auto
 manualTeams.autoFill.tooltip = Distribuisci i giocatori non assegnati in squadre bilanciate attorno alle tue scelte bloccate
 manualTeams.maxPlayers = Giocatori max
 game.pinnedTeamBadge.tooltip = Bloccato nella Squadra {0,number,#} dal host per +autoteam
+map.previewType.heightmap = Mappa altimetrica
+map.previewType.heightmapWater = Mappa altimetrica + acqua
+map.previewOverlay.none = Nessuno

--- a/src/main/resources/i18n/messages_ko.properties
+++ b/src/main/resources/i18n/messages_ko.properties
@@ -2200,3 +2200,6 @@ manualTeams.autoFill = 자동 채우기
 manualTeams.autoFill.tooltip = 미배정 플레이어를 고정한 선택을 중심으로 균형 잡힌 팀에 배치
 manualTeams.maxPlayers = 최대 플레이어
 game.pinnedTeamBadge.tooltip = 호스트가 +autoteam을 위해 팀 {0,number,#}에 고정함
+map.previewType.heightmap = 고도맵
+map.previewType.heightmapWater = 고도맵 + 물
+map.previewOverlay.none = 없음

--- a/src/main/resources/i18n/messages_nl.properties
+++ b/src/main/resources/i18n/messages_nl.properties
@@ -2200,3 +2200,6 @@ manualTeams.autoFill = Auto-invullen
 manualTeams.autoFill.tooltip = Plaats niet-toegewezen spelers in gebalanceerde teams rond je vastgezette keuzes
 manualTeams.maxPlayers = Max. spelers
 game.pinnedTeamBadge.tooltip = Door de host vastgezet in Team {0,number,#} voor +autoteam
+map.previewType.heightmap = Hoogtekaart
+map.previewType.heightmapWater = Hoogtekaart + water
+map.previewOverlay.none = Geen

--- a/src/main/resources/i18n/messages_pl.properties
+++ b/src/main/resources/i18n/messages_pl.properties
@@ -2200,3 +2200,6 @@ manualTeams.autoFill = Autouzupełnianie
 manualTeams.autoFill.tooltip = Rozmieść nieprzypisanych graczy w zrównoważonych drużynach wokół Twoich przypiętych wyborów
 manualTeams.maxPlayers = Maks. graczy
 game.pinnedTeamBadge.tooltip = Przypięty do Drużyny {0,number,#} przez hosta dla +autoteam
+map.previewType.heightmap = Mapa wysokości
+map.previewType.heightmapWater = Mapa wysokości + woda
+map.previewOverlay.none = Brak

--- a/src/main/resources/i18n/messages_pt.properties
+++ b/src/main/resources/i18n/messages_pt.properties
@@ -2200,3 +2200,6 @@ manualTeams.autoFill = Preenchimento auto
 manualTeams.autoFill.tooltip = Coloque os jogadores não atribuídos em equipas equilibradas em torno das suas escolhas fixadas
 manualTeams.maxPlayers = Jogadores máx.
 game.pinnedTeamBadge.tooltip = Fixado na Equipa {0,number,#} pelo anfitrião para +autoteam
+map.previewType.heightmap = Mapa de altura
+map.previewType.heightmapWater = Mapa de altura + água
+map.previewOverlay.none = Nenhum

--- a/src/main/resources/i18n/messages_ru.properties
+++ b/src/main/resources/i18n/messages_ru.properties
@@ -2200,3 +2200,6 @@ manualTeams.autoFill = Автозаполнение
 manualTeams.autoFill.tooltip = Распределить незакреплённых игроков по сбалансированным командам вокруг закреплённого выбора
 manualTeams.maxPlayers = Макс. игроков
 game.pinnedTeamBadge.tooltip = Закреплён в команде {0,number,#} хостом для +autoteam
+map.previewType.heightmap = Карта высот
+map.previewType.heightmapWater = Карта высот + вода
+map.previewOverlay.none = Нет

--- a/src/main/resources/i18n/messages_tr.properties
+++ b/src/main/resources/i18n/messages_tr.properties
@@ -1184,3 +1184,6 @@ manualTeams.autoFill=Otomatik doldur
 manualTeams.autoFill.tooltip=Atanmamış oyuncuları sabitlediğiniz seçimlerin etrafında dengeli takımlara yerleştir
 manualTeams.maxPlayers=Maks. oyuncu
 game.pinnedTeamBadge.tooltip=Ev sahibi tarafından +autoteam için Takım {0,number,#} olarak sabitlendi
+map.previewType.heightmap = Yükseklik haritası
+map.previewType.heightmapWater = Yükseklik haritası + su
+map.previewOverlay.none = Yok

--- a/src/main/resources/i18n/messages_uk.properties
+++ b/src/main/resources/i18n/messages_uk.properties
@@ -2200,3 +2200,6 @@ manualTeams.autoFill = Автозаповнення
 manualTeams.autoFill.tooltip = Розподілити незакріплених гравців по збалансованих командах навколо закріпленого вибору
 manualTeams.maxPlayers = Макс. гравців
 game.pinnedTeamBadge.tooltip = Закріплений у команді {0,number,#} хостом для +autoteam
+map.previewType.heightmap = Карта висот
+map.previewType.heightmapWater = Карта висот + вода
+map.previewOverlay.none = Немає

--- a/src/main/resources/i18n/messages_zh.properties
+++ b/src/main/resources/i18n/messages_zh.properties
@@ -2201,3 +2201,6 @@ manualTeams.autoFill = 自动填充
 manualTeams.autoFill.tooltip = 将未分配的玩家围绕你固定的选择放入平衡的队伍中
 manualTeams.maxPlayers = 最大玩家数
 game.pinnedTeamBadge.tooltip = 主机为 +autoteam 将其固定到队伍 {0,number,#}
+map.previewType.heightmap = 高度图
+map.previewType.heightmapWater = 高度图 + 水
+map.previewOverlay.none = 无

--- a/src/main/resources/theme/play/create_game.fxml
+++ b/src/main/resources/theme/play/create_game.fxml
@@ -32,7 +32,7 @@
         <!-- Settings nested grid: 3 rows (friends/replay/maxplayers, password/replay/rating, reserved-slots-row) -->
         <RowConstraints minHeight="115.0" vgrow="NEVER"/>
         <RowConstraints minHeight="10.0" vgrow="NEVER" />
-        <RowConstraints minHeight="35.0" vgrow="NEVER" valignment="TOP"/>
+        <RowConstraints minHeight="32.0" vgrow="NEVER" valignment="TOP"/>
         <RowConstraints minHeight="35.0" vgrow="NEVER" />
         <RowConstraints maxHeight="480" vgrow="ALWAYS" />
     </rowConstraints>
@@ -105,7 +105,7 @@
         </Separator>
 
         <!-- Game Type -->
-        <Label styleClass="h2" text="%game.create.gameType" GridPane.rowIndex="3"/>
+        <Label styleClass="h2" style="-fx-padding: 0;" text="%game.create.gameType" GridPane.rowIndex="3"/>
         <VBox spacing="10.0" GridPane.columnIndex="0" GridPane.rowIndex="4" GridPane.rowSpan="2" GridPane.vgrow="ALWAYS">
             <ListView fx:id="featuredModListView" VBox.vgrow="SOMETIMES" prefHeight="180"/>
             <HBox alignment="CENTER_LEFT" spacing="10.0">
@@ -136,7 +136,7 @@
         </VBox>
 
         <!-- Map List -->
-        <Label styleClass="h2" text="%game.create.map" GridPane.columnIndex="1" GridPane.rowIndex="3"/>
+        <Label styleClass="h2" style="-fx-padding: 0;" text="%game.create.map" GridPane.columnIndex="1" GridPane.rowIndex="3"/>
         <TextField fx:id="mapSearchTextField" promptText="%game.create.searchMap" GridPane.columnIndex="1"
                    GridPane.rowIndex="4"/>
         <VBox spacing="10.0" GridPane.columnIndex="1" GridPane.rowIndex="5" GridPane.vgrow="ALWAYS">
@@ -150,10 +150,18 @@
         </VBox>
 
         <!-- Map Preview -->
-        <HBox alignment="CENTER" spacing="10.0" GridPane.rowIndex="3" GridPane.columnIndex="2">
-            <Label alignment="CENTER_RIGHT" maxHeight="1.7976931348623157E308"
-                   maxWidth="1.7976931348623157E308" text="%game.create.preview" wrapText="true"/>
-            <ComboBox fx:id="mapPreviewTypeComboBox" maxWidth="1.7976931348623157E308" HBox.hgrow="ALWAYS" />
+        <HBox alignment="CENTER_LEFT" spacing="10.0" GridPane.rowIndex="3" GridPane.columnIndex="2">
+            <Label minWidth="-Infinity" text="%game.create.preview"/>
+            <GridPane hgap="10.0" HBox.hgrow="ALWAYS">
+                <columnConstraints>
+                    <ColumnConstraints hgrow="ALWAYS" percentWidth="50.0"/>
+                    <ColumnConstraints hgrow="ALWAYS" percentWidth="50.0"/>
+                </columnConstraints>
+                <ComboBox fx:id="mapPreviewTypeComboBox" maxWidth="1.7976931348623157E308"
+                          GridPane.columnIndex="0" GridPane.hgrow="ALWAYS"/>
+                <ComboBox fx:id="mapPreviewOverlayComboBox" maxWidth="1.7976931348623157E308"
+                          GridPane.columnIndex="1" GridPane.hgrow="ALWAYS"/>
+            </GridPane>
         </HBox>
         <VBox fx:id="mapPreview" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" GridPane.columnIndex="2"
               GridPane.columnSpan="2" GridPane.rowIndex="4" GridPane.rowSpan="2" GridPane.vgrow="ALWAYS">
@@ -162,28 +170,48 @@
             <StackPane>
                 <Pane fx:id="mapPreviewPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308"
                       styleClass="map-preview" prefHeight="360"/>
+                <Pane fx:id="mapPreviewOverlayPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308"
+                      mouseTransparent="true" prefHeight="360"/>
                 <AnchorPane onMouseEntered="#showMapPreviewContextButton" onMouseExited="#hideMapPreviewContextButton">
                     <Button fx:id="mapPreviewContextButton" text="..." onMouseClicked="#onMapAPreviewPaneClicked"
                             visible="false"
                             AnchorPane.topAnchor="10.0" AnchorPane.rightAnchor="10.0"/>
                 </AnchorPane>
             </StackPane>
-            <HBox alignment="CENTER" spacing="10.0">
-                <Label fx:id="hpiArchiveLabel" text="&lt;archive.ufo&gt;"/>
-                <Label fx:id="mapSizeLabel" text="&lt;Size&gt;" GridPane.columnIndex="1" GridPane.rowIndex="1">
-                    <graphic>
-                        <Region styleClass="icon,map-size-icon" />
-                    </graphic>
+            <VBox alignment="CENTER" maxWidth="1.7976931348623157E308" spacing="0.0">
+                <Label fx:id="mapNameLabel" alignment="CENTER" maxWidth="1.7976931348623157E308" text="&lt;Map name&gt;"/>
+                <Label fx:id="hpiArchiveLabel" alignment="CENTER" maxWidth="1.7976931348623157E308"
+                       styleClass="secondary" text="&lt;archive.ufo&gt;">
+                    <VBox.margin>
+                        <Insets bottom="2.0"/>
+                    </VBox.margin>
                 </Label>
-                <Label fx:id="mapPlayersLabel" text="&lt;MaxPlayers&gt;" GridPane.rowIndex="1">
-                    <graphic>
-                        <Region styleClass="icon,players-icon" />
-                    </graphic>
-                </Label>
-                <Label fx:id="versionLabel" text="&lt;Version&gt;"/>
-            </HBox>
-            <Separator GridPane.columnSpan="2147483647" GridPane.hgrow="ALWAYS"/>
+                <HBox alignment="CENTER" maxWidth="1.7976931348623157E308" spacing="12.0">
+                    <Label fx:id="mapSizeLabel" text="&lt;Size&gt;" GridPane.columnIndex="1" GridPane.rowIndex="1">
+                        <graphic>
+                            <Region styleClass="icon,map-size-icon" />
+                        </graphic>
+                    </Label>
+                    <Label fx:id="mapWindLabel" text="&lt;Wind&gt;" GridPane.rowIndex="1"/>
+                    <Label fx:id="mapTidalLabel" text="&lt;Tidal&gt;" GridPane.rowIndex="1"/>
+                    <Label fx:id="mapWaterLabel" text="&lt;Water&gt;" GridPane.rowIndex="1"/>
+                    <Label fx:id="mapPlayersLabel" text="&lt;MaxPlayers&gt;" GridPane.rowIndex="1">
+                        <graphic>
+                            <Region styleClass="icon,players-icon" />
+                        </graphic>
+                    </Label>
+                    <Label fx:id="versionLabel" text="&lt;Version&gt;"/>
+                </HBox>
+            </VBox>
+            <Separator GridPane.columnSpan="2147483647" GridPane.hgrow="ALWAYS">
+                <VBox.margin>
+                    <Insets bottom="3.0" top="5.0"/>
+                </VBox.margin>
+            </Separator>
             <ScrollPane maxWidth="360" fitToWidth="true" maxHeight="1.7976931348623157E308" VBox.vgrow="ALWAYS">
+                <VBox.margin>
+                    <Insets bottom="12.0"/>
+                </VBox.margin>
                 <Label fx:id="mapDescriptionLabel" alignment="TOP_LEFT" maxHeight="1.7976931348623157E308"
                        maxWidth="360" text="&lt;Description&gt;" wrapText="true"/>
             </ScrollPane>

--- a/src/main/resources/theme/play/create_game.fxml
+++ b/src/main/resources/theme/play/create_game.fxml
@@ -194,7 +194,6 @@
                     </Label>
                     <Label fx:id="mapWindLabel" text="&lt;Wind&gt;" GridPane.rowIndex="1"/>
                     <Label fx:id="mapTidalLabel" text="&lt;Tidal&gt;" GridPane.rowIndex="1"/>
-                    <Label fx:id="mapWaterLabel" text="&lt;Water&gt;" GridPane.rowIndex="1"/>
                     <Label fx:id="mapPlayersLabel" text="&lt;MaxPlayers&gt;" GridPane.rowIndex="1">
                         <graphic>
                             <Region styleClass="icon,players-icon" />


### PR DESCRIPTION
Depends on the taftoolbox PR.

Adds map preview and map info improvements to the create-game screen.

Changes:
- Add base preview selector: minimap, heightmap, heightmap + water
- Add separate overlay selector: none, positions, mexes, geos, rocks, trees
- Show wind, tidal, and water percentage for installed maps
- Show map name and archive name separately
- Improve preview/stat layout in the create-game dialog
- Use local installed map details when possible for ranked/server map entries

Notes:
- Wind/tidal/water are only available when the map exists locally, because the current API does not provide these fields yet.
- Showing those stats before download would need API/database support in a later change.